### PR TITLE
Set many-to-many relation through Requested Services

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -2,6 +2,7 @@ class Booking < ApplicationRecord
 
   has_many :comments
   has_many :requested_services
+  has_many :services, through: :requested_services
 
   belongs_to :cyclist
   belongs_to :mechanic

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,6 +3,7 @@ class Service < ApplicationRecord
   belongs_to :mechanic
 
   has_many :requested_services
+  has_many :bookings, through: :requested_services
 
   validates :service_name, presence: true
   validates :service_price, presence: true,


### PR DESCRIPTION
Bookings and Services are now properly linked in a many-to-many relationship through Requested services so that queries between them no longer need to invoke the join table directly.  This will greatly simplify searches in both directions.