### PR TITLE
Fix scoped routes for reviews

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,7 @@ Rails.application.routes.draw do
 
   resources :cyclists do
     resources :bookings, except: :destroy
-    resources :review_of_cyclists, only: [:index, :show]
-    resources :review_of_mechanics, except: :destroy
+    resources :review_of_cyclists, only: [:new, :create, :edit, :update]
   end
 
   resources :mechanics do
@@ -13,8 +12,7 @@ Rails.application.routes.draw do
     resources :bookings, except: :destroy do
       resources :comments, except: :destroy
     end
-    resources :review_of_mechanics, only: [:index, :show]
-    resources :review_of_cyclists, except: :destroy
+    resources :review_of_mechanics, only: [:new, :create, :edit, :update]
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
Because actions concerning reviews only make sense in the context of the cyclist/mechanic that they are *about*, other routes are superfluous.

The only actions that should be taken wrt reviews are creating them and updating them, both of which make the most sense when done in the context of the person they are about rather than the person who wrote them (though obviously only the person who wrote them should have access to those actions - this means a filter will be required).
Reviews will only be viewed on the profile of the person they are attached to, which does not require a specific action.