### PR TITLE
Changed delete method to destroy on controllers

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -34,7 +34,7 @@ class BookingsController < ApplicationController
     @booking = Booking.find(params[:id])
   end
 
-  def delete
+  def destroy
     @booking = Booking.find(params[:id])
 
     if @booking.destroy

--- a/app/controllers/cyclists_controller.rb
+++ b/app/controllers/cyclists_controller.rb
@@ -34,7 +34,7 @@ class CyclistsController < ApplicationController
     @cyclist = Cyclist.find(session[:id])
   end
 
-  def delete
+  def destroy
     @cyclist = Cyclist.find(session[:id])
     if @cyclist.destroy
       redirect_to mechanics_path

--- a/app/controllers/mechanics_controller.rb
+++ b/app/controllers/mechanics_controller.rb
@@ -42,7 +42,7 @@ class MechanicsController < ApplicationController
     @mechanic = Mechanic.find(session[:id])
   end
 
-  def delete
+  def destroy
     @mechanic = Mechanic.find(session[:id])
     if @mechanic.destroy
       redirect_to mechanics_path

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -33,7 +33,8 @@ class ServicesController < ApplicationController
     @service = Service.find(params[:id])
   end
 
-  def delete
+  def destroy
+    @mechanic = Mechanic.find(session[:id])
     @service = Service.find(params[:id])
 
     if @service.destroy


### PR DESCRIPTION
The destroy methods on controllers are appropriately renamed to destroy from delete due to an error on instantiation.