### PR TITLE
Stop raw mechanics objects from rendering

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -49,7 +49,7 @@
   <div class="ui relaxed divided items">
 
     <!-- Display each mechanic returned from the database -->
-    <%= @mechanics.each do |mechanic| %>
+    <% @mechanics.each do |mechanic| %>
       <div class="item">
 
         <div class="ui small image">


### PR DESCRIPTION
Fix the code that erroneously renders raw mechanic data in the view. The data should be returned to the view for use in the erb sections, but not displayed in bulk.